### PR TITLE
Reworked the Viewmodel animation system

### DIFF
--- a/code/swb_base/ViewModelBase.cs
+++ b/code/swb_base/ViewModelBase.cs
@@ -127,7 +127,7 @@ namespace SWB_Base
             }
 
             // Check for sideways velocity to sway the gun slightly
-            if (this.localVel.x > 0.0f)
+            if (weapon.IsZooming || this.localVel.x > 0.0f)
                 roll = -7.0f*(this.localVel.x/maxWalkSpeed);
             else if (this.localVel.x < 0.0f)
                 yaw = 3.0f*(this.localVel.x/maxWalkSpeed);


### PR DESCRIPTION
As per request of @timmybo5, I have reworked the Viewmodel animation system. I was originally only going to help out with the walking animations, but I thought it'd be better to rewrite the code to be easier for everyone to make changes to it. The old code had a bit of repetitive calculations in it, so I tried to streamline the process as follows:

1) There is are two `Vector3`'s now that get `Lerp`'d every frame, `FinalVectorPos` and `FinalVectorRot`. They `Lerp` to try to match the value of `TargetVectorPos` and `TargetVectorRot` specifically. These vectors are **local vectors**, so you don't need to worry about the player's angles.
2) When an animation wants to be performed, simply perform operations on the `TargetVector`'s. 
3) Animations can be sped up or slowed down by playing with the value of  `animSpeed`.

The same exists for `FOV`, with `FinalFOV` and `TargetFOV` respectively.

I wasn't sure if there was any function for getting the player's velocity transformed from world coordinates to local... So I ended up doing the math manually and stored it in `localVel`. Also, I haven't done anything with `tuckDist`, to be honest I'm not entirely sure what it was, it would always print `-1` for me :sweat_smile:

I've written it in a way that shouldn't require any weapon to be changed, although some numbers in the sprinting animations might need a little tweaking (since the animation now works differently). Regarding how the code is structured/variables are named, I don't know what's the "standard" in C#, so apologies if the code looks "messy". I tried to keep comments to my usual amount (IE, one per small chunk of code).

I'd probably do a bit more work on this if it wasn't such a frustrating experience on weak hardware... And if there was better documentation... :finnadie: