### PR TITLE
Fixed Shotgun spread when aiming & ducking

### DIFF
--- a/code/swb_base/WeaponBase.cs
+++ b/code/swb_base/WeaponBase.cs
@@ -324,7 +324,7 @@ namespace SWB_Base
             float floatMod = 1f;
 
             // Ducking
-            if (Input.Down(InputButton.Duck) && !IsZooming)
+            if (Input.Down(InputButton.Duck) && (!IsZooming || this is WeaponBaseShotty))
                 floatMod -= 0.25f;
 
             // Aiming


### PR DESCRIPTION
There was an issue where if you had your shotgun out, ducked (which decreases recoil) and then tried to ADS then your shotgun would revert back to its original spread instead of using the 'duck' spread.

So you are penalised for ADS'ing while ducking.

https://streamable.com/gdd9ky