### PR TITLE
Hide customization key when customizations are disabled

### DIFF
--- a/code/swb_hud/KeyDisplay.cs
+++ b/code/swb_hud/KeyDisplay.cs
@@ -36,7 +36,7 @@ public class KeyDisplay : Panel
 		SetClass( "hide", !isValidWeapon );
 		if ( !isValidWeapon ) return;
 
-		var showKey = activeWeapon.Attachments.Count == 0 || activeWeapon.IsCustomizing;
-		SetClass( "hide", showKey );
+		var hideKey = activeWeapon.Attachments.Count == 0 || activeWeapon.IsCustomizing || WeaponSettings.Instance.Customization == false;
+		SetClass( "hide", hideKey );
 	}
 }

--- a/code/swb_hud/KeyDisplay.cs
+++ b/code/swb_hud/KeyDisplay.cs
@@ -36,7 +36,7 @@ public class KeyDisplay : Panel
 		SetClass( "hide", !isValidWeapon );
 		if ( !isValidWeapon ) return;
 
-		var hideKey = activeWeapon.Attachments.Count == 0 || activeWeapon.IsCustomizing || WeaponSettings.Instance.Customization == false;
+		var hideKey = activeWeapon.Attachments.Count == 0 || activeWeapon.IsCustomizing || !WeaponSettings.Instance.Customization;
 		SetClass( "hide", hideKey );
 	}
 }


### PR DESCRIPTION
**Solves self-made issue #109** 

- Adds a check for when WeaponSettings.Instance.Customization is set to false to hide the Key UI element.
- Reverts the variable name to correctly correspond with the boolean direction (we are checking if we should hide the key, not show it).

This is my first time making a PR request in this repo! Let me know if you have any questions or if I need to clarify something.