### PR TITLE
Reset Input Sensitivity to 1 if not aiming / scoping

### DIFF
--- a/code/swb_base/Weapon.cs
+++ b/code/swb_base/Weapon.cs
@@ -209,6 +209,8 @@ public partial class Weapon : Component, IInventoryItem
 				Owner.InputSensitivity = ScopeInfo.AimSensitivity;
 			else if ( IsAiming )
 				Owner.InputSensitivity = AimSensitivity;
+			else
+				Owner.InputSensitivity = 1f;
 
 			if ( Scoping )
 			{


### PR DESCRIPTION
`InputSensitivity` is being set when scoping/aiming but doesn't reset in a neutral state. This PR sets sensitivity back to 1 each frame